### PR TITLE
request id middleware

### DIFF
--- a/PhysEdJournal.Api/Middlewares/LogUserGuidMiddleware.cs
+++ b/PhysEdJournal.Api/Middlewares/LogUserGuidMiddleware.cs
@@ -2,7 +2,7 @@
 using Serilog.Context;
 using RequestDelegate = Microsoft.AspNetCore.Http.RequestDelegate;
 
-namespace PhysEdJournal.Api.Monitoring.Logging;
+namespace PhysEdJournal.Api.Middlewares;
 
 public static class LogUserGuidExtensions
 {

--- a/PhysEdJournal.Api/Middlewares/RequestIdMiddleware.cs
+++ b/PhysEdJournal.Api/Middlewares/RequestIdMiddleware.cs
@@ -1,0 +1,52 @@
+using Serilog.Context;
+using Serilog.Core;
+using Serilog.Events;
+
+namespace PhysEdJournal.Api.Middlewares;
+
+public static class RequestIdExtensions
+{
+    public static IApplicationBuilder UseRequestId(this IApplicationBuilder app)
+    {
+        return app.UseMiddleware<RequestIdMiddleware>();
+    }
+}
+
+file struct SerilogRequestIdEnricher : ILogEventEnricher
+{
+    private readonly string _requestId;
+
+    public SerilogRequestIdEnricher(string requestId)
+    {
+        _requestId = requestId;
+    }
+
+    public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
+    {
+        logEvent.AddOrUpdateProperty(
+            new LogEventProperty("RequestId", new ScalarValue(_requestId))
+        );
+    }
+}
+
+public sealed class RequestIdMiddleware
+{
+    private readonly RequestDelegate _next;
+
+    public RequestIdMiddleware(RequestDelegate next)
+    {
+        _next = next;
+    }
+
+    public async Task Invoke(HttpContext context)
+    {
+        context.TraceIdentifier = Guid.NewGuid().ToString();
+
+        context.Response.Headers["x-sx-request-id"] = context.TraceIdentifier;
+
+        using (LogContext.Push(new SerilogRequestIdEnricher(context.TraceIdentifier)))
+        {
+            await _next(context);
+        }
+    }
+}

--- a/PhysEdJournal.Api/Program.cs
+++ b/PhysEdJournal.Api/Program.cs
@@ -12,7 +12,7 @@ using PhysEdJournal.Api.GraphQL;
 using PhysEdJournal.Api.GraphQL.MutationExtensions;
 using PhysEdJournal.Api.GraphQL.QueryExtensions;
 using PhysEdJournal.Api.GraphQL.ScalarTypes;
-using PhysEdJournal.Api.Monitoring.Logging;
+using PhysEdJournal.Api.Middlewares;
 using PhysEdJournal.Infrastructure;
 using PhysEdJournal.Infrastructure.Database;
 using Serilog;
@@ -148,6 +148,8 @@ builder
     );
 
 var app = builder.Build();
+
+app.UseRequestId();
 
 app.UseHttpsRedirection();
 app.UseCors(corsPolicyBuilder =>


### PR DESCRIPTION
Now we generate RequestId in `GUID` format and set it as response header `x-sx-request-id`